### PR TITLE
TransformerPuzzlers.ipynb: Fix test_output()

### DIFF
--- a/TransformerPuzzlers.ipynb
+++ b/TransformerPuzzlers.ipynb
@@ -279,7 +279,7 @@
         "    return seq.map(lambda x: ord(x) - ord('0'))\n",
         "\n",
         "def test_output(user, spec, token_sets):\n",
-        "    for ex_num, token_set in []:        \n",
+        "    for ex_num, token_set in token_sets:        \n",
         "        out1 = user(*token_set[:-1])((token_set[-1]))\n",
         "        out2 = spec(*token_set)\n",
         "        print(f\"Example {ex_num}. Args:\", token_set, \"Expected:\", out2)\n",


### PR DESCRIPTION
Previously, test_output() did not iterative the test suit (it used an empty list instead). This change fixes that.